### PR TITLE
Fix frontend route calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+__pycache__/
+*.pyc

--- a/static/app.js
+++ b/static/app.js
@@ -31,12 +31,14 @@ async function calculateRoute(startAddr, endAddr, apiKey) {
   return json.features[0].geometry;
 }
 
-module.exports = { geocode, calculateRoute };
+if (typeof module !== 'undefined') {
+  module.exports = { geocode, calculateRoute };
+}
 
 // ==== Browser-Init (Leaflet + DOM events) ====
 if (typeof document !== 'undefined') {
   document.addEventListener('DOMContentLoaded', () => {
-    const apiKey  = process.env.ORS_API_KEY || '';
+    const apiKey  = (typeof window !== 'undefined' && window.orsKey) || (typeof process !== 'undefined' && process.env.ORS_API_KEY) || '';
     const map     = L.map('map').setView([47.3769, 8.5417], 13);
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(map);
 

--- a/static/app.test.js
+++ b/static/app.test.js
@@ -1,1 +1,6 @@
-import { autocomplete, geocode, calculateRoute } from './app.js';
+import app from './app.js';
+
+test('exports geocode and calculateRoute functions', () => {
+  expect(typeof app.geocode).toBe('function');
+  expect(typeof app.calculateRoute).toBe('function');
+});


### PR DESCRIPTION
## Summary
- load ORS API key from injected variable
- export route helpers for tests
- add basic Jest test and ignore node_modules

## Testing
- `npm test`
- `pytest tests.py` *(fails: No module named 'transaction')*

------
https://chatgpt.com/codex/tasks/task_e_689262c3d68083208f42d563d0e5ee20