### PR TITLE
Fix frontend route calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+__pycache__/
+*.pyc

--- a/static/app.js
+++ b/static/app.js
@@ -3,40 +3,89 @@
 const L = window.L; // Leaflet global
 
 // ==== Logik-Functions (ohne DOM-Zugriff) ====
+class AppError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.code = code;
+  }
+}
+
 async function geocode(address, apiKey) {
-  const res = await fetch(
-    `https://api.openrouteservice.org/geocode/search?api_key=${apiKey}&text=${encodeURIComponent(address)}`
-  );
-  const data = await res.json();
+  let res;
+  try {
+    res = await fetch(
+      `https://api.openrouteservice.org/geocode/search?api_key=${apiKey}&text=${encodeURIComponent(address)}`
+    );
+  } catch (err) {
+    throw new AppError('GEOCODE_FETCH', err.message);
+  }
+  if (!res.ok) {
+    throw new AppError(`GEOCODE_HTTP_${res.status}`, `HTTP ${res.status}`);
+  }
+  let data;
+  try {
+    data = await res.json();
+  } catch (err) {
+    throw new AppError('GEOCODE_JSON', 'Invalid JSON');
+  }
+  if (!data.features || !data.features.length) {
+    throw new AppError('GEOCODE_NO_RESULTS', 'No results');
+  }
   const [lng, lat] = data.features[0].geometry.coordinates;
   return [lat, lng];
 }
 
 async function calculateRoute(startAddr, endAddr, apiKey) {
-  const [sLat, sLng] = await geocode(startAddr, apiKey);
-  const [eLat, eLng] = await geocode(endAddr, apiKey);
+  let sLat, sLng, eLat, eLng;
+  try {
+    [sLat, sLng] = await geocode(startAddr, apiKey);
+  } catch (err) {
+    err.code = err.code || 'START_GEOCODE';
+    throw err;
+  }
+  try {
+    [eLat, eLng] = await geocode(endAddr, apiKey);
+  } catch (err) {
+    err.code = err.code || 'END_GEOCODE';
+    throw err;
+  }
   const body = { coordinates: [[sLng, sLat], [eLng, eLat]] };
-  const res = await fetch(
-    `https://api.openrouteservice.org/v2/directions/driving-car`,
-    {
+  let res;
+  try {
+    res = await fetch(`https://api.openrouteservice.org/v2/directions/driving-car`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Authorization: apiKey,
       },
       body: JSON.stringify(body),
-    }
-  );
-  const json = await res.json();
+    });
+  } catch (err) {
+    throw new AppError('ROUTE_FETCH', err.message);
+  }
+  if (!res.ok) {
+    throw new AppError(`ROUTE_HTTP_${res.status}`, `HTTP ${res.status}`);
+  }
+  let json;
+  try {
+    json = await res.json();
+  } catch (err) {
+    throw new AppError('ROUTE_JSON', 'Invalid JSON');
+  }
+  if (!json.features || !json.features[0]) {
+    throw new AppError('ROUTE_NO_GEOM', 'No geometry');
+  }
   return json.features[0].geometry;
 }
 
-module.exports = { geocode, calculateRoute };
+if (typeof module !== 'undefined') {
+  module.exports = { geocode, calculateRoute, AppError };
+}
 
 // ==== Browser-Init (Leaflet + DOM events) ====
 if (typeof document !== 'undefined') {
   document.addEventListener('DOMContentLoaded', () => {
-    const apiKey  = process.env.ORS_API_KEY || '';
+    const apiKey  = (typeof window !== 'undefined' && window.orsKey) || (typeof process !== 'undefined' && process.env.ORS_API_KEY) || '';
     const map     = L.map('map').setView([47.3769, 8.5417], 13);
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(map);
 
@@ -57,7 +106,8 @@ if (typeof document !== 'undefined') {
         layer.addTo(map);
         map.fitBounds(layer.getBounds());
       } catch (err) {
-        alert('Route konnte nicht berechnet werden: ' + err.message);
+        const code = err.code ? ` [${err.code}]` : '';
+        alert('Route konnte nicht berechnet werden' + code + ': ' + err.message);
       }
     });
   });

--- a/static/app.test.js
+++ b/static/app.test.js
@@ -1,1 +1,11 @@
-import { autocomplete, geocode, calculateRoute } from './app.js';
+import * as app from './app.js';
+
+test('exports geocode and calculateRoute functions', () => {
+  expect(typeof app.geocode).toBe('function');
+  expect(typeof app.calculateRoute).toBe('function');
+});
+
+test('geocode returns error code on HTTP failure', async () => {
+  global.fetch = jest.fn(async () => ({ ok: false, status: 403, json: async () => ({}) }));
+  await expect(app.geocode('a', 'k')).rejects.toMatchObject({ code: 'GEOCODE_HTTP_403' });
+});


### PR DESCRIPTION
## Summary
- load ORS API key from injected variable
- export route helpers for tests
- add basic Jest test and ignore node_modules
- provide detailed error codes when requests fail
- test that geocode exposes HTTP error codes

## Testing
- `npm test`
- `pip install transaction` *(fails: Could not find a version that satisfies the requirement transaction)*
- `pytest tests.py` *(fails: ModuleNotFoundError: No module named 'transaction')*

------
https://chatgpt.com/codex/tasks/task_e_689262c3d68083208f42d563d0e5ee20